### PR TITLE
Add support for single-class default exports

### DIFF
--- a/fixtures/class.js
+++ b/fixtures/class.js
@@ -1,5 +1,5 @@
 module.exports = class TestClass {
-	constructor(msg) {
-		this.msg = msg;
+	constructor(message) {
+		this.message = message;
 	}
-}
+};

--- a/fixtures/class.js
+++ b/fixtures/class.js
@@ -1,0 +1,5 @@
+module.exports = class TestClass {
+	constructor(msg) {
+		this.msg = msg;
+	}
+}

--- a/fixtures/class.js
+++ b/fixtures/class.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = class TestClass {
 	constructor(message) {
 		this.message = message;

--- a/index.js
+++ b/index.js
@@ -13,9 +13,14 @@ module.exports = fn => {
 			apply: (target, thisArg, argumentsList) => {
 				mod = lazy(mod, fn, id);
 				return Reflect.apply(mod, thisArg, argumentsList);
+			},
+			construct: (target, argumentsList) => {
+				mod = lazy(mod, fn, id);
+				return Reflect.construct(mod, argumentsList);
 			}
 		};
 
-		return new Proxy(() => {}, handler);
+		// eslint-disable-next-line prefer-arrow-callback
+		return new Proxy(function () {}, handler);
 	};
 };

--- a/test.js
+++ b/test.js
@@ -26,10 +26,10 @@ test('props', t => {
 test('class', async t => {
 	const Clazz = importLazy('./fixtures/class.js');
 
-	let inst;
+	let instance;
 	await t.notThrows(() => {
-		inst = new Clazz('42');
+		instance = new Clazz('42');
 	});
-	t.truthy(inst instanceof Clazz);
-	t.is(inst.msg, '42');
+	t.truthy(instance instanceof Clazz);
+	t.is(instance.msg, '42');
 });

--- a/test.js
+++ b/test.js
@@ -23,13 +23,13 @@ test('props', t => {
 	t.is(obj.baz, 'baz');
 });
 
-test('class', async t => {
+test('class', t => {
 	const Clazz = importLazy('./fixtures/class.js');
 
 	let instance;
-	await t.notThrows(() => {
+	t.notThrows(() => {
 		instance = new Clazz('42');
 	});
-	t.truthy(instance instanceof Clazz);
-	t.is(instance.msg, '42');
+	t.true(instance instanceof Clazz);
+	t.is(instance.message, '42');
 });

--- a/test.js
+++ b/test.js
@@ -22,3 +22,14 @@ test('props', t => {
 	t.is(obj.bar('j', 's'), 'barjs');
 	t.is(obj.baz, 'baz');
 });
+
+test('class', async t => {
+	const Clazz = importLazy('./fixtures/class.js');
+
+	let inst;
+	await t.notThrows(() => {
+		inst = new Clazz('42');
+	});
+	t.truthy(inst instanceof Clazz);
+	t.is(inst.msg, '42');
+});


### PR DESCRIPTION
Currently a class-only default export like

```
module.exports = class Test {};
```

can't be lazily imported due to a) the missing `construct`-handler and b) the use of the arrow-function-callback (which allows no constructable calls) and result in a `TypeError`.

I implemented a `construct`-handler, added a test (with fixture) and switched the proxy target to a bare function declaration.